### PR TITLE
Add queue_time to env

### DIFF
--- a/lib/rails_autoscale_agent/collector.rb
+++ b/lib/rails_autoscale_agent/collector.rb
@@ -16,6 +16,8 @@ module RailsAutoscaleAgent
           logger.info "Collected queue_time=#{queue_time_millis}ms request_id=#{request.id} request_size=#{request.size}"
         end
       end
+
+      queue_time_millis
     end
 
   end

--- a/lib/rails_autoscale_agent/middleware.rb
+++ b/lib/rails_autoscale_agent/middleware.rb
@@ -22,7 +22,9 @@ module RailsAutoscaleAgent
 
         store = Store.instance
         Reporter.start(config, store)
-        Collector.collect(request, store) unless request.ignore?
+        unless request.ignore?
+          env["queue_time"] = Collector.collect(request, store)
+        end
       end
 
       @app.call(env)


### PR DESCRIPTION
Since I'd been digging around in the source anyway, here's a small patch to add a `queue_time` attribute to the env hash - this is mainly so that applications we're running can consume that and include it with other metrics we report on each request.