### PR TITLE
Ignore unnamed worker queues

### DIFF
--- a/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
@@ -32,6 +32,7 @@ module WorkerAdapters
       queues = self.class.queues | run_at_by_queue.keys
 
       queues.each do |queue|
+        next if queue.nil? || queue.empty?
         run_at = run_at_by_queue[queue]
         run_at = Time.parse(run_at) if run_at.is_a?(String)
         latency_ms = run_at ? ((t - run_at)*1000).ceil : 0

--- a/lib/rails_autoscale_agent/worker_adapters/que.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/que.rb
@@ -32,6 +32,7 @@ module WorkerAdapters
       self.class.queues |= run_at_by_queue.keys
 
       self.class.queues.each do |queue|
+        next if queue.nil? || queue.empty?
         run_at = run_at_by_queue[queue]
         run_at = Time.parse(run_at) if run_at.is_a?(String)
         latency_ms = run_at ? ((t - run_at)*1000).ceil : 0

--- a/spec/worker_adapters/delayed_job_spec.rb
+++ b/spec/worker_adapters/delayed_job_spec.rb
@@ -71,6 +71,15 @@ module RailsAutoscaleAgent
         expect(store.measurements[1].queue_name).to eq 'low'
       end
 
+      it "ignores unnamed queues" do
+        store = Store.instance
+        ActiveRecord::Base.connection.rows = [[nil, Time.now - 11]]
+
+        subject.collect! store
+
+        expect(store.measurements.size).to eq 0
+      end
+
       it "handles string values for run_at" do
         store = Store.instance
         expected_value = (Time.now - Time.parse('2019-12-04T11:44:45Z')) * 1000

--- a/spec/worker_adapters/que_spec.rb
+++ b/spec/worker_adapters/que_spec.rb
@@ -53,7 +53,10 @@ module RailsAutoscaleAgent
 
       it "always collects for 'default' queue" do
         store = Store.instance
-        ActiveRecord::Base.connection.rows = []
+        ActiveRecord::Base.connection.rows = [
+          # unnamed queue is ignored
+          ['', Time.now - 11],
+        ]
 
         subject.collect! store
 


### PR DESCRIPTION
Not sure if this is possible with Que, but it definitely is with DJ. Without a queue name, these metrics were being lumped with web metrics.