### PR TITLE
Update delayed_job query

### DIFF
--- a/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
@@ -28,7 +28,7 @@ module WorkerAdapters
       t = Time.now
 
       # Ignore failed jobs (they skew latency measurement due to the original run_at)
-      sql = 'SELECT queue, min(run_at) FROM delayed_jobs WHERE attempts = 0 GROUP BY queue'
+      sql = "SELECT queue, min(run_at) FROM delayed_jobs WHERE attempts = 0 and run_at < '#{t.to_s(:db)}' and locked_at is null GROUP BY queue"
       run_at_by_queue = Hash[ActiveRecord::Base.connection.select_rows(sql)]
       queues = self.class.queues | run_at_by_queue.keys
 


### PR DESCRIPTION
The query for delayed job should exclude already started jobs as well as jobs that are scheduled to be started later than now.