### PR TITLE
Allow Ruby v3

### DIFF
--- a/rails_autoscale_agent.gemspec
+++ b/rails_autoscale_agent.gemspec
@@ -16,5 +16,5 @@ Gem::Specification.new do |spec|
   spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
 end


### PR DESCRIPTION
Tweaking the required version slightly to allow MRI 3.x, not just ~> 2.5.

The build passes locally for me if I add `gem "redis-namespace", git: "https://github.com/resque/redis-namespace.git"` to the Gemfile (they've got a commit that relaxes their own Ruby version requirement, it's just not been released in a new version yet).