### PR TITLE
Mute ActiveRecord log noise in Delayed::Job adapter

### DIFF
--- a/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
@@ -12,7 +12,7 @@ module RailsAutoscaleAgent
 
       def enabled?
         if defined?(::Delayed::Job) && defined?(::Delayed::Backend::ActiveRecord)
-          log_msg = String.new("DelayedJob enabled (#{::ActiveRecord::Base.default_timezone})")
+          log_msg = String.new("DelayedJob enabled (#{::ActiveRecord.default_timezone})")
           log_msg << " with long-running job support" if track_long_running_jobs?
           logger.info log_msg
           true

--- a/lib/rails_autoscale_agent/worker_adapters/que.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/que.rb
@@ -37,7 +37,7 @@ module RailsAutoscaleAgent
           GROUP BY 1
         SQL
 
-        run_at_by_queue = Hash[select_rows(sql)]
+        run_at_by_queue = Hash[select_rows_silently(sql)]
 
         # Don't collect worker metrics if there are unreasonable number of queues
         if run_at_by_queue.size > Config.instance.max_queues
@@ -61,6 +61,14 @@ module RailsAutoscaleAgent
       end
 
       private
+
+      def select_rows_silently(sql)
+        if ::ActiveRecord::Base.logger.respond_to?(:silence)
+          ::ActiveRecord::Base.logger.silence { select_rows(sql) }
+        else
+          select_rows(sql)
+        end
+      end
 
       def select_rows(sql)
         # This ensures the agent doesn't hold onto a DB connection any longer than necessary

--- a/lib/rails_autoscale_agent/worker_adapters/que.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/que.rb
@@ -20,7 +20,7 @@ module RailsAutoscaleAgent
 
       def enabled?
         if defined?(::Que)
-          logger.info "Que enabled (#{::ActiveRecord::Base.default_timezone})"
+          logger.info "Que enabled (#{::ActiveRecord.default_timezone})"
           true
         end
       end


### PR DESCRIPTION
Hey @adamlogic, loving Rails Autoscale 🙌

Just one annoyance: My logs were filling up with `ActiveRecord` noise like

```
Jan 1 20:08:35  infoquest-ims  app[web] DEBUG  D, [2022-01-02T01:08:35.516441 #77] DEBUG -- :    (1.2ms)  SELECT COALESCE(queue, 'default'), min(run_at)
Jan 1 20:08:35  infoquest-ims  app[web] info  FROM delayed_jobs
Jan 1 20:08:35  infoquest-ims  app[web] info  WHERE locked_at IS NULL
Jan 1 20:08:35  infoquest-ims  app[web] info  AND failed_at IS NULL
Jan 1 20:08:35  infoquest-ims  app[web] info  GROUP BY queue
Jan 1 20:08:35  infoquest-ims  app[web] info
Jan 1 20:08:35  infoquest-ims  app[web] DEBUG  D, [2022-01-02T01:08:35.518497 #77] DEBUG -- :    (0.8ms)  SELECT COALESCE(queue, 'default'), count(*)
Jan 1 20:08:35  infoquest-ims  app[web] info  FROM delayed_jobs
Jan 1 20:08:35  infoquest-ims  app[web] info  WHERE locked_at IS NOT NULL
Jan 1 20:08:35  infoquest-ims  app[web] info  AND locked_by IS NOT NULL
Jan 1 20:08:35  infoquest-ims  app[web] info  AND failed_at IS NULL
Jan 1 20:08:35  infoquest-ims  app[web] info  GROUP BY 1
Jan 1 20:08:35  infoquest-ims  app[web] info
```

This is a proof of concept PR that mutes the log noise. To be clear, it's a pretty ugly hack. But there's some history behind it. The idea is based on https://github.com/collectiveidea/delayed_job/issues/477#issuecomment-800341818. I've used this technique in several production apps to silence the Delayed::Job log noise. I did a fair bit of digging before I put it in my apps and couldn't find anything better. I'm not sure there's any other solution besides just turning down the log level globally.

I'm currently running my fork of `rails_autoscale_agent` in production and things look ok.

I realize this isn't a complete solution. The `Que` adapter probably has similar log noise. Maybe we want to put this behind a `Config.instance.quiet?` check? But if this looks like a good direction to go, I'm happy to help refactor and get this PR over the finish line.