### PR TITLE
Fix Active Record `default_timezone` detection for different versions

### DIFF
--- a/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/delayed_job.rb
@@ -12,7 +12,7 @@ module RailsAutoscaleAgent
 
       def enabled?
         if defined?(::Delayed::Job) && defined?(::Delayed::Backend::ActiveRecord)
-          log_msg = String.new("DelayedJob enabled (#{::ActiveRecord.default_timezone})")
+          log_msg = String.new("DelayedJob enabled (#{default_timezone})")
           log_msg << " with long-running job support" if track_long_running_jobs?
           logger.info log_msg
           true
@@ -86,6 +86,16 @@ module RailsAutoscaleAgent
 
       def track_long_running_jobs?
         Config.instance.track_long_running_jobs
+      end
+
+      def default_timezone
+        if ::ActiveRecord.respond_to?(:default_timezone)
+          # Rails >= 7
+          ::ActiveRecord.default_timezone
+        else
+          # Rails < 7
+          ::ActiveRecord::Base.default_timezone
+        end
       end
 
       def select_rows_silently(sql)

--- a/lib/rails_autoscale_agent/worker_adapters/que.rb
+++ b/lib/rails_autoscale_agent/worker_adapters/que.rb
@@ -20,7 +20,7 @@ module RailsAutoscaleAgent
 
       def enabled?
         if defined?(::Que)
-          logger.info "Que enabled (#{::ActiveRecord.default_timezone})"
+          logger.info "Que enabled (#{default_timezone})"
           true
         end
       end
@@ -61,6 +61,16 @@ module RailsAutoscaleAgent
       end
 
       private
+
+      def default_timezone
+        if ::ActiveRecord.respond_to?(:default_timezone)
+          # Rails >= 7
+          ::ActiveRecord.default_timezone
+        else
+          # Rails < 7
+          ::ActiveRecord::Base.default_timezone
+        end
+      end
 
       def select_rows_silently(sql)
         if ::ActiveRecord::Base.logger.respond_to?(:silence)


### PR DESCRIPTION
Rails 7 moved the `default_timezone` config from `Base` to the main
`ActiveRecord` module, issuing a warning if you try to access it through
`Base`:

- Rails 7

    > ActiveRecord::Base.default_timezone
    DEPRECATION WARNING: ActiveRecord::Base.default_timezone is
    deprecated and will be removed in Rails 7.1.
    Use `ActiveRecord.default_timezone` instead.

    > ActiveRecord.default_timezone
    => :utc

- Rails 6

    > ActiveRecord::Base.default_timezone
    => :utc

    > ActiveRecord.default_timezone
    NoMethodError (undefined method `default_timezone' for ActiveRecord:Module)

To keep compatibility with different versions of Rails / Active Record,
and avoid the deprecation warning on Rails 7, we need to rely on feature
detection there.

### Testing

#### master

##### Rails 7.x

```
% bundle info activesupport
  * activesupport (7.0.2.2)
```
```
% bundle exec rake
...
Finished in 0.42671 seconds (files took 1.62 seconds to load)
43 examples, 0 failures
```

##### Rails 6.x

```
% bundle info activesupport
  * activesupport (6.1.4.6)
```

```
% bundle exec rake
...
  1) RailsAutoscaleAgent::Middleware#call with RAILS_AUTOSCALE_URL set passes the request up the middleware stack
     Failure/Error: log_msg = String.new("DelayedJob enabled (#{::ActiveRecord.default_timezone})")

     NoMethodError:
       undefined method `default_timezone' for ActiveRecord:Module
     # ./lib/rails_autoscale_agent/worker_adapters/delayed_job.rb:15:in `enabled?'
     # ./lib/rails_autoscale_agent/reporter.rb:20:in `select'
     # ./lib/rails_autoscale_agent/reporter.rb:20:in `start!'
     # ./lib/rails_autoscale_agent/reporter.rb:15:in `start'
     # ./lib/rails_autoscale_agent/middleware.rb:19:in `call'
     # ./spec/middleware_spec.rb:33:in `block (4 levels) in <module:RailsAutoscaleAgent>'
     # ./spec/support/env_helpers.rb:15:in `use_env'
     # ./spec/middleware_spec.rb:30:in `block (4 levels) in <module:RailsAutoscaleAgent>'

  2) RailsAutoscaleAgent::WorkerAdapters::DelayedJob#enabled?
     Failure/Error: log_msg = String.new("DelayedJob enabled (#{::ActiveRecord.default_timezone})")

     NoMethodError:
       undefined method `default_timezone' for ActiveRecord:Module
     # ./lib/rails_autoscale_agent/worker_adapters/delayed_job.rb:15:in `enabled?'
     # ./spec/worker_adapters/delayed_job_spec.rb:17:in `block (3 levels) in <module:RailsAutoscaleAgent>'

  3) RailsAutoscaleAgent::WorkerAdapters::Que#enabled?
     Failure/Error: logger.info "Que enabled (#{::ActiveRecord.default_timezone})"

     NoMethodError:
       undefined method `default_timezone' for ActiveRecord:Module
     # ./lib/rails_autoscale_agent/worker_adapters/que.rb:23:in `enabled?'
     # ./spec/worker_adapters/que_spec.rb:20:in `block (3 levels) in <module:RailsAutoscaleAgent>'

Finished in 0.40502 seconds (files took 1.8 seconds to load)
43 examples, 3 failures

Failed examples:

rspec ./spec/middleware_spec.rb:32 # RailsAutoscaleAgent::Middleware#call with RAILS_AUTOSCALE_URL set passes the request up the middleware stack
rspec ./spec/worker_adapters/delayed_job_spec.rb:17 # RailsAutoscaleAgent::WorkerAdapters::DelayedJob#enabled?
rspec ./spec/worker_adapters/que_spec.rb:20 # RailsAutoscaleAgent::WorkerAdapters::Que#enabled?
```

#### This Branch

##### Rails 7.x

```
% bundle info activesupport
  * activesupport (7.0.2.2)
```
```
% bundle exec rake
...
Finished in 0.44925 seconds (files took 2.09 seconds to load)
43 examples, 0 failures
```

##### Rails 6.x

```
% bundle info activesupport
  * activesupport (6.1.4.6)
```

```
% bundle exec rake
...
Finished in 0.72957 seconds (files took 1.59 seconds to load)
43 examples, 0 failures
```